### PR TITLE
feat: add svg size control props; fix hover effect

### DIFF
--- a/src/components/PrimaryButton/SvgSpriteIcon.tsx
+++ b/src/components/PrimaryButton/SvgSpriteIcon.tsx
@@ -1,16 +1,16 @@
-import { FC } from 'react'
+import { SvgIcon, SvgIconProps } from '@mui/material';
+import { FC } from 'react';
 
-interface SvgSpriteIconProps {
-  svgSpriteId: string
-  svgSize?: number
+interface SvgSpriteIconProps extends SvgIconProps {
+  svgSpriteId: string;
 }
 
-const SvgSpriteIcon: FC<SvgSpriteIconProps> = ({ svgSpriteId, svgSize }) => {
+const SvgSpriteIcon: FC<SvgSpriteIconProps> = ({ svgSpriteId, ...props }) => {
   return (
-    <svg className="icon" style={{ width: `${svgSize}px`, height: `${svgSize}px` }}>
+    <SvgIcon {...props}>
       <use href={`/sprite.svg#${svgSpriteId}`}></use>
-    </svg>
-  )
-}
+    </SvgIcon>
+  );
+};
 
-export default SvgSpriteIcon
+export default SvgSpriteIcon;

--- a/src/components/SharedLayout/SharedLayout.tsx
+++ b/src/components/SharedLayout/SharedLayout.tsx
@@ -1,5 +1,5 @@
-import { FC } from 'react'
-import { Outlet } from 'react-router-dom'
+import { FC } from 'react';
+import { Outlet } from 'react-router-dom';
 
 const SharedLayout: FC = () => {
   return (
@@ -10,7 +10,7 @@ const SharedLayout: FC = () => {
       </main>
       <footer>Footer</footer>
     </div>
-  )
-}
+  );
+};
 
-export default SharedLayout
+export default SharedLayout;

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -1,12 +1,12 @@
-import { Components } from "@mui/material";
-import { MuiButton } from "./themed-components/button.modifier";
-import { MuiContainer } from "./themed-components/container.modifier";
+import { Components } from '@mui/material';
+import { MuiButton } from './themed-components/button.modifier';
+import { MuiContainer } from './themed-components/container.modifier';
+import { MuiSvgIcon } from './themed-components/svgIcon.modifier';
 
-import { Theme } from "@mui/material/styles";
+import { Theme } from '@mui/material/styles';
 
 export const components: Components<Theme> = {
   MuiButton,
   MuiContainer,
+  MuiSvgIcon,
 };
-
-export { MuiContainer };

--- a/src/theme/themed-components/svgIcon.modifier.ts
+++ b/src/theme/themed-components/svgIcon.modifier.ts
@@ -1,0 +1,14 @@
+import { Components, Theme } from '@mui/material/styles';
+
+export const MuiSvgIcon: Components<Theme>['MuiSvgIcon'] = {
+  defaultProps: {
+    fontSize: 'small',
+  },
+  styleOverrides: {
+    root: ({ ownerState }) => ({
+      ...(ownerState.fontSize === 'small' && { fontSize: '1.5rem' }),
+      ...(ownerState.fontSize === 'medium' && { fontSize: '2rem' }),
+      ...(ownerState.fontSize === 'large' && { fontSize: '2.25rem' }),
+    }),
+  },
+};


### PR DESCRIPTION
 - fix: при hover на батьківському елементі, svg іконка змінює колір на вказаний
 - feat:  при використанні  SvgSpriteIcon як параметр можна передати fontSize який керує розміром іконки.
   Є три варіанти розміру:
   - "small"  =>  24x24 px дефолтний, не потрібно вказувати
   - "medium" => 32x32 px
   - "large" => 36x36 px
  Приклад: 
`<SvgSpriteIcon svgSpriteId="clock_icon" fontSize="medium" /> `

 
 