### PR TITLE
feat: add extends ButtonProps to PrimaryBtn

### DIFF
--- a/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/PrimaryButton/PrimaryButton.tsx
@@ -1,24 +1,15 @@
-import { Button } from '@mui/material';
-import { FC, MouseEventHandler } from 'react';
+import { Button, ButtonProps } from '@mui/material';
+import { FC } from 'react';
 import SvgSpriteIcon from './SvgSpriteIcon';
 
-interface PrimaryButtonProps {
+interface PrimaryButtonProps extends ButtonProps {
   title: string;
   svgSpriteId: string;
-  href: string;
-  componentWidth?: number;
-  onClick?: MouseEventHandler;
 }
 
-const PrimaryButton: FC<PrimaryButtonProps> = ({ title, svgSpriteId, componentWidth, href, onClick }) => {
+const PrimaryButton: FC<PrimaryButtonProps> = ({ title, svgSpriteId, ...props }) => {
   return (
-    <Button
-      href={href}
-      target="_blank"
-      variant="primary"
-      onClick={onClick}
-      endIcon={<SvgSpriteIcon svgSpriteId={svgSpriteId} fontSize="small" />}
-      sx={{ width: `${componentWidth}px` }}>
+    <Button variant="primary" {...props} endIcon={<SvgSpriteIcon svgSpriteId={svgSpriteId} fontSize="small" />}>
       {title}
     </Button>
   );


### PR DESCRIPTION
додав наслідування ButtonProps для кнопки, щоб можна було більш гнучко керувати стилями і налаштуваннями кнопки ( через sx, напр ) . Обовʼязковими аргументами залишаються тільки title i svgSpriteId. Зверніть увагу, якщо хтось використовував componentWidth, він працювати не буде.