### PR TITLE
feat: add extends ButtonProps to PrimaryBtn

### DIFF
--- a/src/components/Header/mobile/MobileMainMenu.tsx
+++ b/src/components/Header/mobile/MobileMainMenu.tsx
@@ -1,8 +1,8 @@
-import { FC } from 'react';
 import { Stack } from '@mui/material';
-import NavMenu from '../parts/NavMenu';
+import { FC } from 'react';
 import PrimaryButton from '../../PrimaryButton/PrimaryButton';
 import Info from '../parts/Info';
+import NavMenu from '../parts/NavMenu';
 
 interface MobileMainMenuProp {
   action: () => void;
@@ -13,7 +13,7 @@ const MobileMainMenu: FC<MobileMainMenuProp> = ({ action }) => {
     <Stack gap={6}>
       <NavMenu secondaryAction={action} />
       <Stack alignItems="center">
-        <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" componentWidth={280} />
+        <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" sx={{ width: '280px' }} />
       </Stack>
 
       <Info />

--- a/src/components/Header/mobile/SubMenu.tsx
+++ b/src/components/Header/mobile/SubMenu.tsx
@@ -1,8 +1,8 @@
+import { Button, List, ListItem, ListItemButton, Stack } from '@mui/material';
 import { FC } from 'react';
-import { List, ListItem, ListItemButton, Button, Stack } from '@mui/material';
 import PrimaryButton from '../../PrimaryButton/PrimaryButton';
-import Info from '../parts/Info';
 import SvgSpriteIcon from '../../PrimaryButton/SvgSpriteIcon';
+import Info from '../parts/Info';
 
 interface SubMenuProps {
   onClick: () => void;
@@ -40,7 +40,7 @@ const SubMenu: FC<SubMenuProps> = ({ onClick }) => {
       </Stack>
 
       <Stack alignItems="center">
-        <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" componentWidth={280} />
+        <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" sx={{ width: '280px' }} />
       </Stack>
 
       <Info />

--- a/src/components/Header/mobile/TabletSearch.tsx
+++ b/src/components/Header/mobile/TabletSearch.tsx
@@ -1,9 +1,9 @@
-import { FC, useState } from 'react';
 import { Box, IconButton, Stack, Typography } from '@mui/material';
+import { FC, useState } from 'react';
 import PrimaryButton from '../../PrimaryButton/PrimaryButton';
-import MobileDialog from './MobileDialog';
 import SvgSpriteIcon from '../../PrimaryButton/SvgSpriteIcon';
 import Info from '../parts/Info';
+import MobileDialog from './MobileDialog';
 
 const TabletSearch: FC = () => {
   const [searchEl, setSearchEl] = useState(false);
@@ -25,7 +25,7 @@ const TabletSearch: FC = () => {
         <Stack gap={6}>
           <Typography>Search Results</Typography>
           <Stack alignItems="center">
-            <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" componentWidth={280} />
+            <PrimaryButton href="/" svgSpriteId="ticket_icon" title="Квитки" sx={{ width: '280px' }} />
           </Stack>
           <Info />
         </Stack>

--- a/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/PrimaryButton/PrimaryButton.tsx
@@ -1,24 +1,15 @@
-import { Button } from '@mui/material';
-import { FC, MouseEventHandler } from 'react';
+import { Button, ButtonProps } from '@mui/material';
+import { FC } from 'react';
 import SvgSpriteIcon from './SvgSpriteIcon';
 
-interface PrimaryButtonProps {
+interface PrimaryButtonProps extends ButtonProps {
   title: string;
   svgSpriteId: string;
-  href: string;
-  componentWidth?: number;
-  onClick?: MouseEventHandler;
 }
 
-const PrimaryButton: FC<PrimaryButtonProps> = ({ title, svgSpriteId, componentWidth, href, onClick }) => {
+const PrimaryButton: FC<PrimaryButtonProps> = ({ title, svgSpriteId, ...props }) => {
   return (
-    <Button
-      href={href}
-      target="_blank"
-      variant="primary"
-      onClick={onClick}
-      endIcon={<SvgSpriteIcon svgSpriteId={svgSpriteId} fontSize="small" />}
-      sx={{ width: `${componentWidth}px` }}>
+    <Button variant="primary" {...props} endIcon={<SvgSpriteIcon svgSpriteId={svgSpriteId} fontSize="small" />}>
       {title}
     </Button>
   );


### PR DESCRIPTION
додав наслідування ButtonProps для кнопки, щоб можна було більш гнучко керувати стилями і налаштуваннями кнопки ( через sx, напр ) . Обовʼязковими аргументами залишаються тільки title i svgSpriteId. Вніс зміни до 3 файлів де переписав пропс componentWidth на sx={{}} з відповідними розмірами. 