### PR TITLE
fix: search field does not work until 3 characters are entered

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -38,8 +38,8 @@ const Search: FC = () => {
   };
 
   const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
     if (inputData.length > 2) {
-      e.preventDefault();
       setSearchResults([]);
       setSearchTitleVal(inputData);
       setSearchResults(searchContent(inputData));


### PR DESCRIPTION
Мінорний фікс. 
Поле пошуку на сторінці сторінці виведення результатів не буде спрацьовувати до введення 3 символів. 